### PR TITLE
Fix the Annihilation autobuyer

### DIFF
--- a/src/core/autobuyers/annihilation-autobuyer.js
+++ b/src/core/autobuyers/annihilation-autobuyer.js
@@ -38,7 +38,7 @@ export class AnnihilationAutobuyerState extends AutobuyerState {
   }
 
   tick() {
-    if (Laitela.darkMatterMultGain >= this.multiplier) {
+    if (Laitela.darkMatterMultGain.gte(this.multiplier)) {
       Laitela.annihilate();
     }
   }


### PR DESCRIPTION
`Laitela.darkMatterMultGain` was made a `Decimal`, but the autobuyer code wasn't updated to handle that. This crashed the game when the Annihilation autobuyer is enabled.